### PR TITLE
Changes to read Mario accelerometer

### DIFF
--- a/Sources/BoostBLEKit/Hub/SuperMario.swift
+++ b/Sources/BoostBLEKit/Hub/SuperMario.swift
@@ -10,11 +10,18 @@ import Foundation
 
 public final class SuperMario {
     
+    private static let IOTypeMap: [PortId: IOType] = [
+        0x00: .marioAccelerometer,
+        0x01: .marioColorBarcodeSensor,
+        0x02: .marioPantsSensor,
+        0x06: .voltageSensor,
+    ]
+    
     public final class Mario: Hub {
         
         public init() {}
         
-        public var connectedIOs: [PortId: IOType] = [:]
+        public var connectedIOs: [PortId: IOType] = IOTypeMap
         
         public let portMap: [Port: PortId] = [:]
     }
@@ -23,7 +30,7 @@ public final class SuperMario {
         
         public init() {}
         
-        public var connectedIOs: [PortId: IOType] = [:]
+        public var connectedIOs: [PortId: IOType] = IOTypeMap
         
         public let portMap: [Port: PortId] = [:]
     }
@@ -32,7 +39,7 @@ public final class SuperMario {
         
         public init() {}
         
-        public var connectedIOs: [PortId: IOType] = [:]
+        public var connectedIOs: [PortId: IOType] = IOTypeMap
         
         public let portMap: [Port: PortId] = [:]
     }

--- a/Sources/BoostBLEKit/IOType.swift
+++ b/Sources/BoostBLEKit/IOType.swift
@@ -184,7 +184,7 @@ extension IOType {
         case .smallAngularMotor:
             return 3 // 0: ??, 1: Speed, 2: Position, 3: Absolute Position
         case .marioAccelerometer:
-            return nil
+            return 0 // 0: Tilt (x, y, z)
         case .marioColorBarcodeSensor:
             return 0 // 0: TAG, 1: RGB
         case .marioPantsSensor:


### PR DESCRIPTION
Changed the defaultSensorMode to get the value from `.marioAccelerometer` sensor. Also added `connectedIOs` map for Super Mario devices.

It works more like a Gyroscope, and it seems that the 3 numbers are signed integers between -32 / +32 showing tilt in 3 directions.